### PR TITLE
Implement RemoveFieldsInterceptor to backend

### DIFF
--- a/api/src/users/dtos/user.dto.ts
+++ b/api/src/users/dtos/user.dto.ts
@@ -1,0 +1,9 @@
+import { Expose } from 'class-transformer';
+
+export class UserDto {
+	@Expose()
+	username: string;
+
+	@Expose()
+	email: string;
+}

--- a/api/src/users/interceptors/remove-fields.interceptor.ts
+++ b/api/src/users/interceptors/remove-fields.interceptor.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { plainToInstance } from 'class-transformer';
+import { UserDto } from '../dtos/user.dto';
+
+export class RemoveFieldsInterceptor implements NestInterceptor {
+	intercept(context: ExecutionContext, handler: CallHandler): Observable<any> {
+		// run something before a request is handled by the request handler
+
+		return handler.handle().pipe(
+			map((data: any) => {
+				return plainToInstance(UserDto, data, {
+					excludeExtraneousValues: true,
+				});
+			}),
+		);
+	}
+}

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -7,10 +7,14 @@ import {
 	Post,
 	Patch,
 	Delete,
+	UseInterceptors,
 } from '@nestjs/common';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { UpdateUserDto } from './dtos/update-user.dto';
 import { UsersService } from './users.service';
+import { RemoveFieldsInterceptor } from './interceptors/remove-fields.interceptor';
+
+@UseInterceptors(RemoveFieldsInterceptor)
 @Controller('auth')
 export class UsersController {
 	constructor(private usersService: UsersService) {}

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -19,6 +19,7 @@ export class UsersService {
 			if (!user) {
 				throw new NotFoundException('User not found');
 			}
+
 			return user;
 		} catch (error) {
 			throw new InternalServerErrorException('Failed to get user');


### PR DESCRIPTION
Closes #14 

This PR creates an interceptor currently only used on the `users` controller. Previously the user controller returned all sorts of unnecessary information such as `created_at`, `updated_at`, and `password`. This interceptor _intercepts_ the request before it is returned to the route handler and transforms the object returned to only include `username` and `email` (as the DTO is currently marked the `@Expose()` decorator.)

I can't think of any places where returning that other info would be useful.

To test it simply run the backend and hit the routes (specifically `Get('/:id')`) and view the response which should contain all the user's info. Then fetch this PR and re-attempt, which should not contain the above mentioned info.