### PR TITLE
Implement Authorization and Authentication in backend

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,12 +20,15 @@
 		"db:generate": "npx --yes prisma generate --schema=prisma/schema.prisma"
 	},
 	"dependencies": {
+		"@fastify/secure-session": "^7.1.0",
 		"@nestjs/common": "^10.0.0",
 		"@nestjs/config": "^3.1.1",
 		"@nestjs/core": "^10.0.0",
 		"@nestjs/platform-express": "^10.0.0",
 		"@nestjs/platform-fastify": "^10.1.2",
 		"@prisma/client": "^5.3.0",
+		"@types/cookie-session": "^2.0.45",
+		"argon2": "^0.31.1",
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.14.0",
 		"reflect-metadata": "^0.1.13",

--- a/api/src/guards/auth.guard.ts
+++ b/api/src/guards/auth.guard.ts
@@ -1,0 +1,9 @@
+import { CanActivate, ExecutionContext } from '@nestjs/common';
+
+export class AuthGuard implements CanActivate {
+	canActivate(context: ExecutionContext) {
+		const request = context.switchToHttp().getRequest();
+
+		return request.session.userId;
+	}
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -5,6 +5,7 @@ import {
 	NestFastifyApplication,
 } from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
+import secureSession from '@fastify/secure-session';
 
 const address = '0.0.0.0';
 const port = 3000;
@@ -18,6 +19,10 @@ async function bootstrap() {
 		adapter,
 	);
 	app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+	await app.register(secureSession, {
+		secret: `${process.env.SECRET}`,
+		salt: `${process.env.SALT}`,
+	});
 	await app.listen(port, address);
 }
 bootstrap();

--- a/api/src/prisma/prisma.module.ts
+++ b/api/src/prisma/prisma.module.ts
@@ -5,4 +5,4 @@ import { PrismaService } from './prisma.service';
 	providers: [PrismaService],
 	exports: [PrismaService],
 })
-export default class PrismaModule {}
+export class PrismaModule {}

--- a/api/src/users/auth.service.ts
+++ b/api/src/users/auth.service.ts
@@ -1,0 +1,53 @@
+import {
+	BadRequestException,
+	Injectable,
+	InternalServerErrorException,
+} from '@nestjs/common';
+import { UsersService } from './users.service';
+import * as argon2 from 'argon2';
+
+@Injectable()
+export class AuthService {
+	constructor(private usersService: UsersService) {}
+
+	async signup(username: string, email: string, password: string) {
+		// See if email is in use
+		const userExists = await this.usersService.getUserByEmail(email);
+
+		if (userExists !== null) {
+			throw new BadRequestException('email in use');
+		}
+
+		// Hash user's password with Argon2
+		try {
+			const hashedPassword = await argon2.hash(password);
+
+			// Create a new user with the hashed password
+			const user = await this.usersService.createUser({
+				username,
+				email,
+				password: hashedPassword,
+			});
+
+			return user;
+		} catch (error) {
+			throw new InternalServerErrorException('Failed to create user');
+		}
+	}
+
+	async signin(email: string, password: string) {
+		const user = await this.usersService.getUserByEmail(email);
+
+		if (!user) {
+			throw new BadRequestException('User not found');
+		}
+
+		const passwordsMatch = await argon2.verify(user.password, password);
+
+		if (!passwordsMatch) {
+			throw new BadRequestException('Incorrect password');
+		}
+
+		return user;
+	}
+}

--- a/api/src/users/decorators/current-user.decorator.ts
+++ b/api/src/users/decorators/current-user.decorator.ts
@@ -1,0 +1,16 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/*	
+	this decorator gives us the current user authenticated by the system
+	decorators cannot make use of DI thus we need an interceptor.
+
+	the decorator cannot run without first making use of the CurrentUserInterceptor
+*/
+export const CurrentUser = createParamDecorator(
+	(data: never, context: ExecutionContext) => {
+		// the current request object passing through the handler
+		const request = context.switchToHttp().getRequest();
+
+		return request.currentUser;
+	},
+);

--- a/api/src/users/dtos/signin-user.dto.ts
+++ b/api/src/users/dtos/signin-user.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class SigninUserDto {
+	@IsEmail()
+	email: string;
+
+	@IsString()
+	password: string;
+}

--- a/api/src/users/interceptors/current-user.interceptor.ts
+++ b/api/src/users/interceptors/current-user.interceptor.ts
@@ -1,0 +1,27 @@
+import {
+	NestInterceptor,
+	ExecutionContext,
+	CallHandler,
+	Injectable,
+} from '@nestjs/common';
+import { UsersService } from '../users.service';
+
+@Injectable()
+export class CurrentUserInterceptor implements NestInterceptor {
+	constructor(private usersServer: UsersService) {}
+
+	async intercept(context: ExecutionContext, handler: CallHandler) {
+		const request = context.switchToHttp().getRequest();
+		const { userId } = request.session;
+
+		if (userId) {
+			const user = await this.usersServer.getUser(userId);
+
+			// attach the current user to each request going through the users service
+			request.currentUser = user;
+		}
+
+		// continue running the next handler in the chain
+		return handler.handle();
+	}
+}

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -8,37 +8,77 @@ import {
 	Patch,
 	Delete,
 	UseInterceptors,
+	Session,
+	UseGuards,
 } from '@nestjs/common';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { UpdateUserDto } from './dtos/update-user.dto';
+import { SigninUserDto } from './dtos/signin-user.dto';
 import { UsersService } from './users.service';
 import { RemoveFieldsInterceptor } from './interceptors/remove-fields.interceptor';
+import { AuthService } from './auth.service';
+import { CurrentUser } from './decorators/current-user.decorator';
+import { AuthGuard } from '../guards/auth.guard';
 
 @UseInterceptors(RemoveFieldsInterceptor)
 @Controller('auth')
 export class UsersController {
-	constructor(private usersService: UsersService) {}
+	constructor(
+		private usersService: UsersService,
+		private authService: AuthService,
+	) {}
 
+	@UseGuards(AuthGuard)
+	@Get('/whoami')
+	whoAmI(@CurrentUser() user: CreateUserDto) {
+		return user;
+	}
+
+	@UseGuards(AuthGuard)
 	@Get('/:id')
 	fetchUserById(@Param('id') id: string) {
 		return this.usersService.getUser(parseInt(id));
 	}
 
+	@UseGuards(AuthGuard)
 	@Get()
 	fetchUserByEmail(@Query('email') email: string) {
 		return this.usersService.getUserByEmail(email);
 	}
 
-	@Post('/signup')
-	createUser(@Body() body: CreateUserDto) {
-		return this.usersService.createUser(body);
+	@UseGuards(AuthGuard)
+	@Post('/signout')
+	signout(@Session() session: any) {
+		session.userId = null;
 	}
 
+	@Post('/signup')
+	async signup(@Body() body: CreateUserDto, @Session() session: any) {
+		const user = await this.authService.signup(
+			body.username,
+			body.email,
+			body.password,
+		);
+		session.userId = user.id;
+
+		return user;
+	}
+
+	@Post('/signin')
+	async signin(@Body() body: SigninUserDto, @Session() session: any) {
+		const user = await this.authService.signin(body.email, body.password);
+		session.userId = user.id;
+
+		return user;
+	}
+
+	@UseGuards(AuthGuard)
 	@Patch('/:id')
 	updateUser(@Param('id') id: string, @Body() body: UpdateUserDto) {
 		return this.usersService.updateUser(parseInt(id), body);
 	}
 
+	@UseGuards(AuthGuard)
 	@Delete('/:id')
 	removeUser(@Param('id') id: string) {
 		return this.usersService.removeUser(parseInt(id));

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -1,11 +1,19 @@
 import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import PrismaModule from '../prisma/prisma.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthService } from './auth.service';
+import { CurrentUserInterceptor } from './interceptors/current-user.interceptor';
 
 @Module({
 	imports: [PrismaModule],
 	controllers: [UsersController],
-	providers: [UsersService],
+	providers: [
+		UsersService,
+		AuthService,
+		// globally (user) scoped interceptor
+		{ provide: APP_INTERCEPTOR, useClass: CurrentUserInterceptor },
+	],
 })
 export class UsersModule {}

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -11,6 +11,11 @@ export class UsersService {
 	constructor(private prisma: PrismaService) {}
 
 	async getUser(id: number) {
+		// if an id is not passed return null- used in GET /whoami
+		if (!id) {
+			return null;
+		}
+
 		try {
 			const user = await this.prisma.user.findUnique({
 				where: { id },
@@ -32,11 +37,7 @@ export class UsersService {
 				where: { email },
 			});
 
-			if (!user) {
-				throw new NotFoundException('User not found');
-			}
-
-			return user;
+			return user || null;
 		} catch (error) {
 			throw new InternalServerErrorException('Failed to get user');
 		}


### PR DESCRIPTION
Closes #13, #1

This PR implements many things and has many moving parts:
- It implements an `Auth Service` which hashes and (randomly) salts a user's `password` and stores it in the db.
    - Naturally it also implements `/signin` and `/signup` routes and required functionalities (see `auth.service.ts`).
- It adds a fastify-based cookie session system which responds by setting the current user's `userId` to a cookie upon `/signin` and clears it from the session object upon `/signout`.
- It adds an `AuthGuard` which protects several user service routes from users who aren't currently authenticated.
    - This `AuthGuard` relies on a `CurrentUserDecorator` which relies on a `CurrentUserInterceptor`- both have been implemented as well. I've tried to add comments where necessary for basic explanations.

To test this PR pull it from the repo and attempt to execute any route that is now protected:
- `Get('/whoami')`
- `Get('/:id')`
- `Get('/')`
- `Post('/signout')`
- `Patch('/:id')`
- `Delete('/:id')`

It should respond with `403 Forbidden` where applicable when not authenticated. Simply sign-in (via `Post('/signin')`) to register the user's `userId` to the cookie and re-attempt to execute any of the above routes which should now be permitted.