### PR TITLE
chore(api): add `maxAge` to cookie

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -32,6 +32,7 @@ export class AppModule {
 			.apply(
 				cookieSession({
 					keys: [this.configService.get('COOKIE_SECRET')],
+					maxAge: 30 * 24 * 60 * 60 * 1000,
 				}),
 			)
 			.forRoutes('*');


### PR DESCRIPTION
## Issue
Closes #35 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds a 30 day range to the authorization cookie returned by the backend to the user. The cookie will expire and SELF DESTRUCT after 30 days of the user not logging out.

## Testing the PR
(Ensure you are currently logged out then) Log in as a user as normal and observe the `Set-Cookie` header returned after logging in.

```
Set-Cookie | session=eyJ1c2VySWQiOjF9; path=/; expires=Thu, 09 Nov 2023 13:21:43 GMT; httponly
```
maxAge: 30 * 24 * 60 * 60 * 1000

<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
