### PR TITLE
Issue 38: Implement email service

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -42,6 +42,8 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
+          MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
+          MAILGUN_KEY: ${{ secrets.MAILGUN_KEY }}
         run: |
           cd api
           npm install

--- a/api/package.json
+++ b/api/package.json
@@ -30,6 +30,7 @@
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.14.0",
 		"cookie-session": "^2.0.0",
+		"mailgun.js": "^9.3.0",
 		"reflect-metadata": "^0.1.13",
 		"rxjs": "^7.8.1",
 		"uuid": "^9.0.1"

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -6,12 +6,13 @@ import { UsersModule } from './users/users.module';
 import { ListsModule } from './lists/lists.module';
 import { PrismaService } from './prisma/prisma.service';
 import { APP_PIPE } from '@nestjs/core';
+import { EmailModule } from './email/email.module';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const cookieSession = require('cookie-session');
 
 @Module({
-	imports: [ConfigModule.forRoot(), UsersModule, ListsModule],
+	imports: [ConfigModule, UsersModule, ListsModule, EmailModule],
 	controllers: [AppController],
 	providers: [
 		AppService,

--- a/api/src/email/email.module.ts
+++ b/api/src/email/email.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EmailService } from './email.service';
+import { ConfigService } from '@nestjs/config';
+
+@Module({
+	providers: [EmailService, ConfigService],
+	exports: [EmailService],
+})
+export class EmailModule {}

--- a/api/src/email/email.service.spec.ts
+++ b/api/src/email/email.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmailService } from './email.service';
+
+describe.skip('EmailService', () => {
+	let service: EmailService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [EmailService],
+		}).compile();
+
+		service = module.get<EmailService>(EmailService);
+	});
+
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/api/src/email/email.service.ts
+++ b/api/src/email/email.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Mailgun from 'mailgun.js';
+import { IMailgunClient } from 'mailgun.js/Interfaces';
+import * as FormData from 'form-data';
+
+type EmailData = {
+	from: string;
+	to: string[] | string;
+	subject: string;
+	html: string;
+};
+
+let mailgunApiKey: string;
+let mailgunDomain: string;
+let isProduction: string;
+
+@Injectable()
+export class EmailService {
+	private mailgunClient: IMailgunClient;
+
+	constructor(private readonly configService: ConfigService) {
+		mailgunApiKey = this.configService.get<string>('MAILGUN_KEY') as string;
+		mailgunDomain = this.configService.get<string>('MAILGUN_DOMAIN') as string;
+		isProduction = this.configService.get<string>('NODE_ENV') as string;
+
+		if (!mailgunApiKey || !mailgunDomain) {
+			throw new Error('Mailgun API key or domain is not configured');
+		}
+
+		const mailgun = new Mailgun(FormData);
+		this.mailgunClient = mailgun.client({
+			username: 'api',
+			key: mailgunApiKey,
+		});
+	}
+
+	private async sendEmail(messageData: EmailData) {
+		if (isProduction === 'production') {
+			try {
+				const email = await this.mailgunClient.messages.create(
+					mailgunDomain,
+					messageData,
+				);
+				console.log(`EmailService  sendEmail  email:`, email);
+			} catch (error) {
+				console.log('Error attempting to send email: ', error);
+			}
+		}
+	}
+
+	async sendSignupEmail(recipient: string, username: string) {
+		const email = {
+			from: 'CineSync <mail@cinesync.me>',
+			to: recipient,
+			subject: 'Welcome to CineSync!',
+			html: `
+			<style>
+			@import url('https://fonts.cdnfonts.com/css/courier-prime');
+			p {
+				font-family: 'Courier Prime', sans-serif;
+			}
+			</style>
+			<p>Hi there ${username},</p>
+			<p>We're thrilled to welcome you to CineSync! 🎉</p>
+			<p>Thank you for joining our community. You're now part of a growing network of users who want to curate, manage, and share their most loved movies.</p>
+			<p>To get started and learn more about our service, visit our about page at <a href="https://cinesync.me/about">https://cinesync.me/about</a>. There you can find information about our application and how it works.
+			<br/>If you have any questions or need assistance, please don't hesitate to reach out to our team at <a href="mailto:cinesync@proton.me">cinesync@proton.me</a>.</p>
+			<p>We look forward to seeing you thrive in our community and hope you enjoy every moment of your journey with us.</p>
+			<p>With love,</p>
+			<p>The CineSync Team</p>
+			`,
+		};
+
+		await this.sendEmail(email);
+	}
+
+	async sendListSharingEmail(
+		users: string[],
+		listId: string,
+		listOwner: string,
+	) {
+		const email = {
+			from: 'CineSync <mail@cinesync.me>',
+			to: users,
+			subject: 'A user has shared a list with you on CineSync!',
+			html: `
+			<style>
+			@import url('https://fonts.cdnfonts.com/css/courier-prime');
+			p {
+				font-family: 'Courier Prime', sans-serif;
+			}
+			</style>
+			<p>Hi there ${users},</p>
+			<p>${listOwner} has shared the movie list "${listId}" with you on CineSync! 🎬</p>
+			<p>Click <a href="https://cinesync.me/lists/${listId}">here</a> to view the list.
+			<br/>If you have any questions or need assistance, please don't hesitate to reach out to our team at <a href="mailto:cinesync@proton.me">cinesync@proton.me</a>.</p>
+			<p>Enjoy exploring the movies!</p>
+			<p>With love,</p>
+			<p>The CineSync Team</p>
+			`,
+		};
+
+		await this.sendEmail(email);
+	}
+
+	async sendAccountDeletionEmail(recipient: string) {
+		const email = {
+			from: 'CineSync <mail@cinesync.me>',
+			to: recipient,
+			subject: 'Your account has been deleted on CineSync',
+			html: `
+			<style>
+			@import url('https://fonts.cdnfonts.com/css/courier-prime');
+			p {
+				font-family: 'Courier Prime', sans-serif;
+			}
+			</style>
+			<p>Hi there ${recipient},</p>
+			<p>Your CineSync account has been successfully deleted. We're sorry to see you go. 😢</p>
+			<p>If you ever decide to return, we'll be here to welcome you back with open arms.</p>
+			<p>If you have any feedback or questions, please don't hesitate to reach out to our team at <a href="mailto:cinesync@proton.me">cinesync@proton.me</a>.</p>
+			<p>Thank you for being a part of our community, and we hope to see you again in the future!</p>
+			<p>With love,</p>
+			<p>The CineSync Team</p>
+			`,
+		};
+
+		await this.sendEmail(email);
+	}
+}

--- a/api/src/lists/lists.module.ts
+++ b/api/src/lists/lists.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ListsController } from './lists.controller';
 import { ListsService } from './lists.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-	imports: [PrismaModule],
+	imports: [PrismaModule, EmailModule],
 	controllers: [ListsController],
 	providers: [ListsService],
 })

--- a/api/src/users/users.controller.spec.ts
+++ b/api/src/users/users.controller.spec.ts
@@ -5,11 +5,14 @@ import { AuthService } from './auth.service';
 import { User } from '@prisma/client';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { CreateUserDto } from './dtos/create-user.dto';
+import { EmailModule } from '../email/email.module';
+import { EmailService } from '../email/email.service';
 
 describe('UsersController', () => {
 	let controller: UsersController;
 	let fakeUsersService: Partial<UsersService>;
 	let fakeAuthService: Partial<AuthService>;
+	let fakeEmailService: Partial<EmailService>;
 
 	beforeEach(async () => {
 		fakeUsersService = {
@@ -57,6 +60,14 @@ describe('UsersController', () => {
 				return Promise.resolve({ id: '-1', username, email } as User);
 			},
 		};
+		fakeEmailService = {
+			sendSignupEmail: () => {
+				return Promise.resolve();
+			},
+			sendAccountDeletionEmail: () => {
+				return Promise.resolve();
+			},
+		};
 
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [UsersController],
@@ -70,7 +81,12 @@ describe('UsersController', () => {
 					provide: AuthService,
 					useValue: fakeAuthService,
 				},
+				{
+					provide: EmailService,
+					useValue: fakeEmailService,
+				},
 			],
+			imports: [EmailModule],
 		}).compile();
 
 		controller = module.get<UsersController>(UsersController);

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -4,9 +4,10 @@ import { UsersService } from './users.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthService } from './auth.service';
 import { CurrentUserMiddleware } from './middlewares/current-user.middleware';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-	imports: [PrismaModule],
+	imports: [PrismaModule, EmailModule],
 	controllers: [UsersController],
 	providers: [UsersService, AuthService],
 })


### PR DESCRIPTION
## Issue
Closes #38 

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds an email service, which will send out emails to users given certain events (so far, account creation, list sharing, and account deletion only).

## Testing the PR
The `.env` file needs to be updated to add the sandbox environment for mailgun testing which I can provide upon request. However when using the sandbox environment only pre-authorized emails can be sent. To test this throughly:
1. Give me your email you'd like to send emails to
2. Modify the code in the backend to send an email only to that email (ex: `sendListSharingEmail` takes an array of emails which won't work if all emails are not on the authorized list)
3. Fire the request and an email should be sent to that respective email only

Given the headache of testing this I'm open to approving this w/o testing. Everything seems as if it'll integrate to prod just fine and I've tested everything locally while writing the service.

## Checklist
- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
