### PR TITLE
Issue 5: Allow access to public lists, allow users to change list privacy

### DIFF
--- a/api/src/guards/list.guard.ts
+++ b/api/src/guards/list.guard.ts
@@ -24,6 +24,21 @@ export class ListAuthorizationGuard implements CanActivate {
 				return false;
 			}
 
+			// allow access if list is public and no user is logged in
+			if (!list.is_private && !currentUser) {
+				return true;
+			}
+
+			// allow access if list is public and user is logged in
+			if (!list.is_private && currentUser) {
+				return true;
+			}
+
+			// restrict access if no user is logged in
+			if (!currentUser) {
+				return false;
+			}
+
 			// check if list belongs to the user or has been shared with the user
 			const isCreator = list.creator_id === currentUser.id;
 			const isSharedWithUser =

--- a/api/src/lists/dtos/list.dto.ts
+++ b/api/src/lists/dtos/list.dto.ts
@@ -1,4 +1,5 @@
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
 
 class MovieItem {
 	@Expose()
@@ -42,5 +43,12 @@ class ListItem {
 
 export class ListDto {
 	@Expose()
+	@Type(() => ListItem)
+	@ValidateNested()
 	List: ListItem[];
+
+	@Expose()
+	@Type(() => MovieItem)
+	@ValidateNested()
+	Movie: MovieItem[];
 }

--- a/api/src/lists/lists.controller.ts
+++ b/api/src/lists/lists.controller.ts
@@ -21,7 +21,6 @@ import { ListAuthorizationGuard } from '../guards/list.guard';
 import { EmailService } from '../email/email.service';
 
 @UseInterceptors(RemoveListFieldsInterceptor)
-@UseGuards(AuthGuard)
 @Controller('lists')
 export class ListsController {
 	constructor(
@@ -31,20 +30,23 @@ export class ListsController {
 
 	@UseGuards(ListAuthorizationGuard)
 	@Get('/:listId')
-	getList(@Param('listId') listId: string, @CurrentUser() user: UserDto) {
-		return this.listsService.getList(parseInt(listId), user.id);
+	getList(@Param('listId') listId: string) {
+		return this.listsService.getList(parseInt(listId));
 	}
 
+	@UseGuards(AuthGuard)
 	@Get('/')
 	getLists(@CurrentUser() user: UserDto) {
 		return this.listsService.getLists(user.id);
 	}
 
+	@UseGuards(AuthGuard)
 	@Post('/create')
 	createList(@Body() body: CreateListDto, @CurrentUser() user: UserDto) {
 		return this.listsService.createList(body, user.id);
 	}
 
+	@UseGuards(AuthGuard)
 	@Post('/shareId/:listId')
 	shareList(
 		@Param('listId') listId: string,
@@ -58,6 +60,7 @@ export class ListsController {
 		);
 	}
 
+	@UseGuards(AuthGuard)
 	@Post('/share/:listId')
 	async shareListByEmail(
 		@Param('listId') listId: string,
@@ -79,6 +82,7 @@ export class ListsController {
 		return list;
 	}
 
+	@UseGuards(AuthGuard)
 	@Post('/unshare/:listId')
 	unshareList(
 		@Param('listId') listId: string,
@@ -92,7 +96,16 @@ export class ListsController {
 		);
 	}
 
-	@UseGuards(ListAuthorizationGuard)
+	@UseGuards(ListAuthorizationGuard, AuthGuard)
+	@Patch('/updatePrivacy/:listId')
+	updateListPrivacy(
+		@Param('listId') listId: string,
+		@CurrentUser() user: UserDto,
+	) {
+		return this.listsService.updateListPrivacy(parseInt(listId), user.id);
+	}
+
+	@UseGuards(ListAuthorizationGuard, AuthGuard)
 	@Patch('/update/:listId')
 	updateList(
 		@Param('listId') listId: string,
@@ -107,6 +120,7 @@ export class ListsController {
 		return this.listsService.deleteList(parseInt(listId), user.id);
 	}
 
+	@UseGuards(AuthGuard)
 	@Delete('/delete/:listId/:movieId')
 	deleteListItem(
 		@Param('listId') listId: string,


### PR DESCRIPTION
## Issue
Closes #5

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds functionality to allow a user to make their list public/private (all lists remain private by default). It also allows the public (non-authorized users) to access public lists.

## Testing the PR
Set a list to public via the new `PATCH /lists/updatePrivacy/{listId}` route, then access the list signed out, or signed in. The respective behaviour should occur.

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
