### PR TITLE
Issue-49: Header Logo Longest Contentful Paint

### DIFF
--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -55,6 +55,7 @@ const Header = () => {
 							width={150}
 							alt="CineSync Logo"
 							style={{ margin: '1px' }}
+							priority={true}
 						/>
 					</Link>
 				</Box>


### PR DESCRIPTION
## Issue
<!--
Automatically close the issue when this PR is merged
    USAGE: Fixes/Closes #<issue number>
-->
Fixes/Closes #49 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
<!-- Please add a detailed description of what this PR does and why it is needed -->
The Cinesync logo in the Header was listed as the longest contentful paint, causing longer render times. The `priority` parameter for this image component was set to `true` to cause it to pre-render and improve client render speed.

## Testing the PR
<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->
No change, see [readme](https://github.com/chrispinkney/cinesync#running-cinesync)

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
