### PR TITLE
Issue-76: Add `sharees` endpoint

### DIFF
--- a/api/src/dao/list.dao.ts
+++ b/api/src/dao/list.dao.ts
@@ -49,6 +49,27 @@ export class ListDao {
 		});
 	}
 
+	async getSharees(listId: string) {
+		const list = await this.prisma.list.findUniqueOrThrow({
+			where: { id: listId },
+			include: {
+				User: {
+					orderBy: {
+						username: 'asc',
+					},
+					select: {
+						id: true,
+						username: true,
+						email: true,
+						// avatar: true,
+					},
+				},
+			},
+		});
+
+		return list;
+	}
+
 	async createList(createList: CreateListDto, userId: string) {
 		const list = await this.prisma.list.create({
 			data: {
@@ -122,7 +143,7 @@ export class ListDao {
 		});
 	}
 
-	async updateList(listId: string, updateListDto: UpdateListDto) {
+	async updateList(updateListDto: UpdateListDto) {
 		let newMovies = [];
 		// add new movies to list
 		if (updateListDto?.Movie?.length) {
@@ -151,7 +172,7 @@ export class ListDao {
 						data: {
 							List: {
 								connect: {
-									id: listId,
+									id: updateListDto.listId,
 								},
 							},
 						},
@@ -161,10 +182,9 @@ export class ListDao {
 		}
 
 		return await this.prisma.list.update({
-			where: { id: listId },
+			where: { id: updateListDto.listId },
 			data: {
 				name: updateListDto.name,
-				is_private: updateListDto.is_private,
 			},
 			include: { Movie: true },
 		});

--- a/api/src/guards/list.guard.ts
+++ b/api/src/guards/list.guard.ts
@@ -9,7 +9,7 @@ export class ListAuthorizationGuard implements CanActivate {
 		const request = context.switchToHttp().getRequest();
 		const { user } = request;
 
-		const listId = request.params.listId || request.query.listId;
+		const listId = request.query.listId || request.body.listId;
 
 		const list = await this.prisma.list.findUniqueOrThrow({
 			where: { id: listId },

--- a/api/src/lists/dtos/update-list.dto.ts
+++ b/api/src/lists/dtos/update-list.dto.ts
@@ -1,21 +1,14 @@
 import { Type } from 'class-transformer';
-import {
-	IsString,
-	IsOptional,
-	IsArray,
-	ValidateNested,
-	IsBoolean,
-} from 'class-validator';
+import { IsString, IsOptional, IsArray, ValidateNested } from 'class-validator';
 import { MovieDto } from './movie.dto';
 
 export class UpdateListDto {
+	@IsString()
+	listId: string;
+
 	@IsOptional()
 	@IsString()
 	name: string;
-
-	@IsOptional()
-	@IsBoolean()
-	is_private: boolean;
 
 	@IsArray()
 	@ValidateNested({ each: true })

--- a/api/src/lists/lists.controller.ts
+++ b/api/src/lists/lists.controller.ts
@@ -1,6 +1,5 @@
 import {
 	Controller,
-	Param,
 	Body,
 	Get,
 	Post,
@@ -34,8 +33,8 @@ export class ListsController {
 
 	@UseInterceptors(RemoveListCreateFieldsInterceptor)
 	@UseGuards(ListAuthorizationGuard)
-	@Get('/:listId')
-	getList(@Param('listId') listId: string) {
+	@Get('/list')
+	getList(@Query('listId') listId: string) {
 		return this.listsService.getList(listId);
 	}
 
@@ -44,6 +43,13 @@ export class ListsController {
 	getLists(@Req() req: Request) {
 		if (!req.user) throw new BadRequestException('req contains no user');
 		return this.listsService.getLists(req.user.id);
+	}
+
+	@UseGuards(ListAuthorizationGuard)
+	@Get('/sharees')
+	getSharees(@Query('listId') listId: string, @Req() req: Request) {
+		if (!req.user) throw new BadRequestException('req contains no user');
+		return this.listsService.getSharees(listId, req.user.id);
 	}
 
 	@UseInterceptors(RemoveListCreateFieldsInterceptor)
@@ -57,8 +63,7 @@ export class ListsController {
 	@UseGuards(ListAuthorizationGuard)
 	@Post('/toggleShare')
 	async toggleShareList(
-		@Query('listId') listId: string,
-		@Query('email') email: string,
+		@Body() { listId, email }: { listId: string; email: string },
 		@Req() req: Request,
 	) {
 		if (!req.user) throw new BadRequestException('req contains no user');
@@ -76,24 +81,24 @@ export class ListsController {
 
 	@UseInterceptors(RemoveListFieldsInterceptor)
 	@UseGuards(ListAuthorizationGuard)
-	@Patch('/updatePrivacy/:listId')
+	@Patch('/updatePrivacy')
 	@HttpCode(HttpStatus.NO_CONTENT)
-	updateListPrivacy(@Param('listId') listId: string) {
+	updateListPrivacy(@Body() { listId }: { listId: string }) {
 		return this.listsService.updateListPrivacy(listId);
 	}
 
 	@UseInterceptors(RemoveListCreateFieldsInterceptor)
 	@UseGuards(ListAuthorizationGuard)
-	@Patch('/update/:listId')
-	updateList(@Param('listId') listId: string, @Body() body: UpdateListDto) {
-		return this.listsService.updateList(listId, body);
+	@Patch('/update')
+	updateList(@Body() body: UpdateListDto) {
+		return this.listsService.updateList(body);
 	}
 
 	@UseInterceptors(RemoveListFieldsInterceptor)
 	@UseGuards(ListAuthorizationGuard)
-	@Delete('/delete/:listId')
+	@Delete('/delete')
 	@HttpCode(HttpStatus.NO_CONTENT)
-	deleteList(@Param('listId') listId: string, @Req() req: Request) {
+	deleteList(@Body() { listId }: { listId: string }, @Req() req: Request) {
 		if (!req.user) throw new BadRequestException('req contains no user');
 		return this.listsService.deleteList(listId, req.user.id);
 	}
@@ -103,8 +108,7 @@ export class ListsController {
 	@Delete('/deleteMovie')
 	@HttpCode(HttpStatus.NO_CONTENT)
 	deleteMovie(
-		@Query('listId') listId: string,
-		@Query('movieId') movieId: string,
+		@Body() { listId, movieId }: { listId: string; movieId: string },
 	) {
 		return this.listsService.deleteListItem(listId, movieId);
 	}

--- a/api/src/lists/lists.service.ts
+++ b/api/src/lists/lists.service.ts
@@ -15,6 +15,22 @@ export class ListsService {
 		return await this.listDao.getLists(userId);
 	}
 
+	async getSharees(listId: string, userId: string) {
+		const list = await this.listDao.getSharees(listId);
+
+		const creator = list.User.find((user) => user.id === list.creator_id);
+
+		const filteredList = list.User.filter((user) => userId !== user.id).map(
+			({ username, email }) => ({
+				username,
+				email,
+				creator: username === creator?.username,
+			}),
+		);
+
+		return filteredList;
+	}
+
 	async createList(createList: CreateListDto, userId: string) {
 		return await this.listDao.createList(createList, userId);
 	}
@@ -23,8 +39,8 @@ export class ListsService {
 		return await this.listDao.updateListPrivacy(listId);
 	}
 
-	async updateList(listId: string, updateListDto: UpdateListDto) {
-		return await this.listDao.updateList(listId, updateListDto);
+	async updateList(updateListDto: UpdateListDto) {
+		return await this.listDao.updateList(updateListDto);
 	}
 
 	async deleteList(listId: string, userId: string) {


### PR DESCRIPTION
## Issue
Closes #76

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds the ability to get all list sharees.

## Testing the PR
`git switch main`
`git pull`
`git switch issue-76`
Share a list someone, or multiple someones and:
- GET `{{BASE_URL}}/lists/sharees?listId={{listId}}`
- Response:
```json
[
    {
        "username": "chrispinkney",
        "email": "hey@chrispinkney.com",
        "creator": false
    },
    {
        "username": "test",
        "email": "test@test.test",
        "creator": false
    }
]
```

**Also**! I changed several list related routes. Params are no longer welcome in the CineSync backend and swift action has taken place. See the file changes for the route changes. The frontend will have to change as a result but I'm not sure if it uses those yet (except `share` I think?) As usual I'll pass along my updated postman file.

## Checklist
<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
