### PR TITLE
Issue-101: Add Key Property to Add Movie Skeleton Components

### DIFF
--- a/web/src/components/List/MovieListTable/MovieAddModal.tsx
+++ b/web/src/components/List/MovieListTable/MovieAddModal.tsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import { fetchTmdbMovie, searchTmdbMovies } from '@/utils/tmdb-api';
@@ -98,23 +98,20 @@ const MovieAddModal = ({
 						style={{ height: 476, overflow: 'auto' }}
 					>
 						{searchResults?.map((tmdbMovie: TmdbMovieLite, index: number) => (
-							<>
+							<Fragment key={tmdbMovie.id}>
 								<MovieCard
-									key={tmdbMovie.id}
 									tmdbMovie={tmdbMovie}
 									handleAddMovie={handleAddMovie}
 								/>
-								{index < searchResults.length - 1 && (
-									<Divider key={`divider${tmdbMovie.id}`} />
-								)}
-							</>
+								{index < searchResults.length - 1 && <Divider />}
+							</Fragment>
 						))}
 						{loadingResults &&
-							[...Array(5)].map((i) => (
-								<>
-									<Skeleton variant="rectangular" height={92} key={i} />
-									{i < 5 && <Divider key={`divider${i}`} />}
-								</>
+							[...Array(5)].map((_val, i) => (
+								<Fragment key={i}>
+									<Skeleton variant="rectangular" height={92} />
+									{i < 5 && <Divider />}
+								</Fragment>
 							))}
 					</Stack>
 				</Collapse>


### PR DESCRIPTION
## Issue
<!--
Automatically close the issue when this PR is merged
    USAGE: Fixes/Closes #<issue number>
-->
Fixes #101 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR fixes the warning received when searching for movies from TMDB. Both the `<MovieCard>` stack and `<Skeleton>` stacks contained key props in their components, but the warning was coming from the `<>` fragments directly in the map function. The `<>` tags were changed to `<Fragment>`s and the key props were added there.

## Testing the PR
<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->
- Run preview
- Open browser console
- Navigate to a list and add a movie
- Verify no key prop warnings are received

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
