### PR TITLE
fix(web): fix list context useEffect() dependency

### DIFF
--- a/web/src/context/lists.context.tsx
+++ b/web/src/context/lists.context.tsx
@@ -5,6 +5,7 @@ import {
 	Fragment,
 	ReactNode,
 	createContext,
+	useCallback,
 	useContext,
 	useEffect,
 	useState,
@@ -20,7 +21,7 @@ export const ListsContextProvider = ({ children }: { children: ReactNode }) => {
 	const { token } = useGlobalContext();
 
 	// refreshListsContext will be provided so that child components can easily re-fetch data so page will be re-rendered
-	const refreshListsContext = async () => {
+	const refreshListsContext = useCallback(async () => {
 		const response = await fetch(`${process.env.NEXT_PUBLIC_URL}/lists`, {
 			method: 'GET',
 			headers: {
@@ -30,12 +31,12 @@ export const ListsContextProvider = ({ children }: { children: ReactNode }) => {
 		});
 		const fetchedLists = (await response.json()).List;
 		setLists(fetchedLists);
-	};
+	}, [token]);
 
 	// Fetch once upon initial context load
 	useEffect(() => {
 		refreshListsContext();
-	}, []);
+	}, [refreshListsContext]);
 
 	// Automatically provide context to child components
 	return (

--- a/web/src/context/movielist.context.tsx
+++ b/web/src/context/movielist.context.tsx
@@ -6,6 +6,7 @@ import {
 	ReactNode,
 	SetStateAction,
 	createContext,
+	useCallback,
 	useContext,
 	useEffect,
 	useState,
@@ -38,7 +39,7 @@ export const MovieListContextProvider = ({
 	const { token } = useGlobalContext();
 
 	// refreshMovieListContext will be provided so that child components can easily re-fetch data so page will be re-rendered
-	const refreshMovieListContext = async () => {
+	const refreshMovieListContext = useCallback(async () => {
 		const response = await fetch(
 			`${process.env.NEXT_PUBLIC_URL}/lists/list?` +
 				new URLSearchParams({
@@ -55,12 +56,12 @@ export const MovieListContextProvider = ({
 		const fetchedMovieList = (await response.json()).list;
 		setMovieList(fetchedMovieList);
 		setMovieListTableRows(fetchedMovieList.Movie);
-	};
+	}, [listId, token]);
 
 	// Fetch once upon initial context load
 	useEffect(() => {
 		refreshMovieListContext();
-	}, []);
+	}, [refreshMovieListContext]);
 
 	// Automatically provide context to child components
 	return (


### PR DESCRIPTION
## Issue
<!--
Automatically close the issue when this PR is merged
    USAGE: Fixes/Closes #<issue number>
-->
Fixes #107 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
<!-- Please add a detailed description of what this PR does and why it is needed -->
As stated in #107, the `useEffect()` hooks in the lists/movielist contexts are missing dependencies of the data refresh functions. These have been memoized using `useCallback()` and passed into the `useEffect()` dependencies. Memoization ensures the `useEffect()` hook is not called repeatedly.

## Testing the PR
<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->
To ensure the context is updating correctly, try to delete a list from the /lists page. The list should be removed from the list grid without any reloading.

This should also be done to ensure the movielist context works by deleting a movie on a movielist page .

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
