### PR TITLE
Issue-73: Add list privacy to frontend

### DIFF
--- a/web/src/components/List/ListActions.tsx
+++ b/web/src/components/List/ListActions.tsx
@@ -2,20 +2,27 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import ShareIcon from '@mui/icons-material/Share';
 import IconButton from '@mui/material/IconButton';
-import { Fragment, useState } from 'react';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { useState } from 'react';
 import ListShareModal from '@/components/List/ListShareModal';
 import ListDeleteConfirmationModal from '@/components/List/ListDeleteConfirmationModal';
 import Tooltip from '@mui/material/Tooltip';
+import { toggleListPrivacy } from '@/utils/cinesync-api/fetch-list';
+import { useGlobalContext } from '@/context/store';
 
 const ListActions = ({
 	listId,
-	refreshContext,
 	name,
+	isPrivate,
+	refreshContext,
 }: {
 	listId: string;
-	refreshContext: () => Promise<void>;
 	name: string;
+	isPrivate: boolean;
+	refreshContext: () => Promise<void>;
 }) => {
+	const { token } = useGlobalContext();
 	const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 	const [shareModalOpen, setShareModalOpen] = useState(false);
 
@@ -24,8 +31,15 @@ const ListActions = ({
 	const handleShareModalOpen = () => setShareModalOpen(true);
 	const handleShareModalClose = () => setShareModalOpen(false);
 
+	const handlePrivacyClick = async () => {
+		const { success } = await toggleListPrivacy({ token, listId });
+		if (success) {
+			refreshContext();
+		}
+	};
+
 	return (
-		<Fragment>
+		<>
 			<Tooltip title="Share list">
 				<IconButton
 					sx={{
@@ -46,6 +60,20 @@ const ListActions = ({
 				listId={listId}
 				name={name}
 			/>
+			<Tooltip title={isPrivate ? 'Private' : 'Public'}>
+				<IconButton
+					sx={{
+						'&:hover': {
+							backgroundColor: 'info.main',
+							color: 'info.contrastText',
+						},
+					}}
+					aria-label="toggle privacy"
+					onClick={handlePrivacyClick}
+				>
+					{isPrivate ? <VisibilityOffIcon /> : <VisibilityIcon />}
+				</IconButton>
+			</Tooltip>
 			<Tooltip title="Delete list">
 				<IconButton
 					sx={{
@@ -68,7 +96,7 @@ const ListActions = ({
 				refreshContext={refreshContext}
 				name={name}
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/web/src/components/List/ListGrid/ListCard.tsx
+++ b/web/src/components/List/ListGrid/ListCard.tsx
@@ -11,7 +11,7 @@ import CardActions from '@mui/material/CardActions';
 import ListActions from '../ListActions';
 import { useLists } from '@/context/lists.context';
 
-const ListCard = ({ id, name, movie }: MovieList) => {
+const ListCard = ({ id, name, isPrivate, movie }: MovieList) => {
 	const { refreshListsContext } = useLists();
 	const movieCount = movie.length;
 	const firstFiveMovies: MovieItem[] = movie.slice(0, 5);
@@ -53,6 +53,7 @@ const ListCard = ({ id, name, movie }: MovieList) => {
 						listId={id}
 						refreshContext={refreshListsContext}
 						name={name}
+						isPrivate={isPrivate}
 					/>
 				</CardActions>
 			</Card>

--- a/web/src/components/List/ListGrid/ListGrid.tsx
+++ b/web/src/components/List/ListGrid/ListGrid.tsx
@@ -11,9 +11,14 @@ const ListGrid = () => {
 		<Fragment>
 			<Grid container spacing={4}>
 				{lists &&
-					lists.map(({ id, name, movie }) => (
+					lists.map(({ id, name, isPrivate, movie }) => (
 						<Grid xs={6} lg={4} xl={3} key={id}>
-							<ListCard id={id} name={name} movie={movie} />
+							<ListCard
+								id={id}
+								name={name}
+								isPrivate={isPrivate}
+								movie={movie}
+							/>
 						</Grid>
 					))}
 			</Grid>

--- a/web/src/components/List/MovieListGrid/MovieListContainer.tsx
+++ b/web/src/components/List/MovieListGrid/MovieListContainer.tsx
@@ -77,11 +77,12 @@ const MovieListContainer = () => {
 						alignItems="center"
 					>
 						<MovieListTitle name={movieList.name} />
-						<Box>
+						<Box display="flex" flexDirection={{ xs: 'column', md: 'row' }}>
 							<ListActions
 								listId={movieList.id}
 								refreshContext={refreshMovieListContext}
 								name={movieList.name}
+								isPrivate={movieList.isPrivate}
 							/>
 						</Box>
 					</Grid>

--- a/web/src/components/List/MovieListGrid/MovieListTitle.tsx
+++ b/web/src/components/List/MovieListGrid/MovieListTitle.tsx
@@ -45,16 +45,19 @@ const MovieListTitle = ({ name }: { name: string }) => {
 		<Box display="flex" flexDirection="row" alignItems="center">
 			{!editing ? (
 				<>
-					<Typography variant="h2" color="primary" mr={1}>
+					<Typography
+						variant="h2"
+						color="primary"
+						mr={1}
+						fontSize="calc(20px + 2vw)"
+					>
 						{title}
-					</Typography>
-					<Box alignItems="center">
 						<Tooltip title="Edit Title">
 							<IconButton aria-label="edit" onClick={handleEditClick}>
 								<EditIcon />
 							</IconButton>
 						</Tooltip>
-					</Box>
+					</Typography>
 				</>
 			) : (
 				<>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -21,7 +21,7 @@ type MovieItem = {
 type MovieList = {
 	id: string;
 	name: string;
-	isPrivate?: boolean;
+	isPrivate: boolean;
 	creatorId?: number;
 	createdAt?: Date;
 	updatedAt?: Date;


### PR DESCRIPTION
## Issue
<!--
Automatically close the issue when this PR is merged
    USAGE: Fixes/Closes #<issue number>
-->
Closes #73 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR adds a privacy toggle button to movie lists in the `ListActions.tsx` component. This component is used in both the main lists page and movie list pages.

Additionally, so styling was adjusted to sit well with the addition of the new icon button:
- The movie list title edit button has been moved inline with the title so that it doesn't sit up against the ListActions icons in smaller viewports.
- The ListActions icons have been set to display in a column for smaller viewports so that the list title has more room.

## Testing the PR
<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->
Test toggling privacy from both the list and move list pages on the Vercel preview.

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
