### PR TITLE
Issue-110: Refactor Avatar service

### DIFF
--- a/api/prisma/migrations/20231104160656_/migration.sql
+++ b/api/prisma/migrations/20231104160656_/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `avatar` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "avatar";
+
+-- CreateTable
+CREATE TABLE "Avatar" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "avatar" BYTEA,
+
+    CONSTRAINT "Avatar_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Avatar_user_id_key" ON "Avatar"("user_id");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -39,7 +39,6 @@ model User {
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
   role           Role
-  avatar         Bytes?
   list           List[]
   friendsWith    Friends[] @relation("user_1")
   friendsRequest Friends[] @relation("user_2")
@@ -67,6 +66,12 @@ model Comment {
   listId    String   @map("list_id")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+}
+
+model Avatar {
+  id     String @id @default(uuid())
+  userId String @unique @map("user_id")
+  avatar Bytes?
 }
 
 enum Role {

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,16 +1,17 @@
 import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_PIPE } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaService } from './prisma/prisma.service';
 import { UsersModule } from './users/users.module';
 import { ListsModule } from './lists/lists.module';
-import { PrismaService } from './prisma/prisma.service';
 import { EmailModule } from './email/email.module';
-import { JwtService } from '@nestjs/jwt';
+import { AvatarModule } from './users/avatar/avatar.module';
 
 @Module({
-	imports: [ConfigModule, UsersModule, ListsModule, EmailModule],
+	imports: [ConfigModule, UsersModule, ListsModule, EmailModule, AvatarModule],
 	controllers: [AppController],
 	providers: [
 		AppService,

--- a/api/src/lists/daos/list.dao.ts
+++ b/api/src/lists/daos/list.dao.ts
@@ -73,7 +73,6 @@ export class ListDao {
 						id: true,
 						username: true,
 						email: true,
-						avatar: true,
 					},
 				},
 			},

--- a/api/src/users/auth/auth.service.spec.ts
+++ b/api/src/users/auth/auth.service.spec.ts
@@ -27,7 +27,6 @@ describe('AuthService', () => {
 					createdAt: new Date(),
 					updatedAt: new Date(),
 					role: Role.USER,
-					avatar: null,
 				};
 
 				users.push(user);

--- a/api/src/users/avatar/avatar.module.ts
+++ b/api/src/users/avatar/avatar.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserDao } from '../daos/user.dao';
+import { PrismaModule } from '../../prisma/prisma.module';
+
+@Module({
+	imports: [PrismaModule],
+	providers: [UserDao],
+})
+export class AvatarModule {}

--- a/api/src/users/avatar/avatar.service.spec.ts
+++ b/api/src/users/avatar/avatar.service.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AvatarService } from './avatar.service';
+import { UserDao } from '../daos/user.dao';
+import { AvatarDao } from '../daos/avatar.dao';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('AvatarService', () => {
+	let service: AvatarService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [AvatarService, UserDao, AvatarDao, PrismaService],
+		}).compile();
+
+		service = module.get<AvatarService>(AvatarService);
+	});
+
+	it('should be defined', () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/api/src/users/avatar/avatar.service.ts
+++ b/api/src/users/avatar/avatar.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UserDao } from '../daos/user.dao';
+import { AvatarDao } from '../daos/avatar.dao';
+import { Response } from 'express';
+
+@Injectable()
+export class AvatarService {
+	constructor(private userDao: UserDao, private avatarDao: AvatarDao) {}
+
+	private async fetchAvatar(userId: string, res: Response) {
+		const { avatar } = await this.avatarDao.getAvatar(userId);
+
+		if (!avatar) {
+			throw new NotFoundException('No avatar found');
+		}
+
+		res.writeHead(200, {
+			'Content-Type': 'image/jpeg',
+			'Content-Length': avatar.length,
+		});
+
+		res.end(avatar);
+
+		return res;
+	}
+
+	async getAvatarByUsername(username: string, res: Response) {
+		const user = await this.userDao.getUserByUsername(username);
+		return this.fetchAvatar(user.id, res);
+	}
+
+	async getAvatar(userId: string, res: Response) {
+		return this.fetchAvatar(userId, res);
+	}
+
+	async updateAvatar(userId: string, avatar: Express.Multer.File) {
+		const avatarData = avatar?.buffer;
+		await this.avatarDao.updateAvatar(userId, avatarData);
+	}
+
+	async deleteUserAvatar(userId: string) {
+		return await this.avatarDao.deleteUserAvatar(userId);
+	}
+}

--- a/api/src/users/daos/avatar.dao.ts
+++ b/api/src/users/daos/avatar.dao.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class AvatarDao {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async getAvatar(userId: string) {
+		const avatar = await this.prisma.avatar.findFirstOrThrow({
+			where: { userId },
+		});
+
+		return avatar;
+	}
+
+	async updateAvatar(userId: string, avatar: Buffer) {
+		const { id } = await this.prisma.avatar.upsert({
+			where: { userId },
+			create: { userId, avatar },
+			update: { avatar },
+		});
+
+		return id;
+	}
+
+	async deleteUserAvatar(userId: string) {
+		await this.prisma.avatar.findUniqueOrThrow({
+			where: {
+				userId,
+			},
+		});
+
+		return await this.prisma.avatar.delete({
+			where: { userId },
+		});
+	}
+}

--- a/api/src/users/daos/user.dao.ts
+++ b/api/src/users/daos/user.dao.ts
@@ -80,13 +80,6 @@ export class UserDao {
 		});
 	}
 
-	async updateAvatar(userId: string, avatar: Buffer) {
-		await this.prisma.user.update({
-			where: { id: userId },
-			data: { avatar },
-		});
-	}
-
 	async updateFriendship(
 		userId: string,
 		friendId: string,
@@ -129,13 +122,6 @@ export class UserDao {
 	async deleteUser(userId: string) {
 		return await this.prisma.user.delete({
 			where: { id: userId },
-		});
-	}
-
-	async deleteUserAvatar(userId: string) {
-		return await this.prisma.user.update({
-			where: { id: userId },
-			data: { avatar: null },
 		});
 	}
 }

--- a/api/src/users/users.controller.spec.ts
+++ b/api/src/users/users.controller.spec.ts
@@ -10,6 +10,9 @@ import { EmailModule } from '../email/email.module';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { ListsService } from '../lists/lists.service';
 import { ListsModule } from '../lists/lists.module';
+import { AvatarModule } from './avatar/avatar.module';
+import { AvatarService } from './avatar/avatar.service';
+import { Response } from 'express';
 
 describe('UsersController', () => {
 	let controller: UsersController;
@@ -17,6 +20,7 @@ describe('UsersController', () => {
 	let fakeAuthService: Partial<AuthService>;
 	let fakeEmailService: Partial<EmailService>;
 	let fakeListsService: Partial<ListsService>;
+	let fakeAvatarService: Partial<AvatarService>;
 
 	beforeEach(async () => {
 		fakeUsersService = {
@@ -123,6 +127,27 @@ describe('UsersController', () => {
 				});
 			},
 		};
+		fakeAvatarService = {
+			async getAvatarByUsername(
+				username: string,
+				res: Response<any, Record<string, any>>,
+			) {
+				return res.status(200).json({ username });
+			},
+			async getAvatar(userId: string, res: Response<any, Record<string, any>>) {
+				return res.status(200).json({ userId });
+			},
+			deleteUserAvatar: (userId: string) => {
+				return Promise.resolve({
+					id: userId,
+					userId: 'uuid',
+					avatar: null,
+				});
+			},
+			updateAvatar: () => {
+				return Promise.resolve();
+			},
+		};
 
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [UsersController],
@@ -144,8 +169,12 @@ describe('UsersController', () => {
 					provide: ListsService,
 					useValue: fakeListsService,
 				},
+				{
+					provide: AvatarService,
+					useValue: fakeAvatarService,
+				},
 			],
-			imports: [EmailModule, ListsModule],
+			imports: [EmailModule, ListsModule, AvatarModule],
 		}).compile();
 
 		controller = module.get<UsersController>(UsersController);

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -14,6 +14,9 @@ import { JwtStrategy } from './auth/passport/jwt.strategy';
 import { CommentDao } from '../lists/daos/comment.dao';
 import { AuthService } from './auth/auth.service';
 import { AuthModule } from './auth/auth.module';
+import { AvatarService } from './avatar/avatar.service';
+import { AvatarModule } from './avatar/avatar.module';
+import { AvatarDao } from './daos/avatar.dao';
 
 @Module({
 	imports: [
@@ -22,6 +25,7 @@ import { AuthModule } from './auth/auth.module';
 		PassportModule,
 		ConfigModule,
 		AuthModule,
+		AvatarModule,
 	],
 	controllers: [UsersController],
 	providers: [
@@ -29,6 +33,8 @@ import { AuthModule } from './auth/auth.module';
 		AuthService,
 		ListsService,
 		JwtService,
+		AvatarService,
+		AvatarDao,
 		UserDao,
 		ListDao,
 		CommentDao,

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,11 +1,6 @@
-import {
-	BadRequestException,
-	Injectable,
-	NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { UserDao } from './daos/user.dao';
-import { Response } from 'express';
 
 export type FriendStatus = 'ACCEPT' | 'REJECT' | 'SENT' | 'PENDING';
 
@@ -27,23 +22,6 @@ export class UsersService {
 
 	async getUsernameById(userId: string) {
 		return await this.userDao.getUsernameById(userId);
-	}
-
-	async getAvatar(userId: string, res: Response) {
-		const user = await this.userDao.getUser(userId);
-
-		if (user?.avatar) {
-			const imageData = user.avatar;
-
-			res.writeHead(200, {
-				'Content-Type': 'image/*',
-				'Content-Length': imageData.length,
-			});
-
-			res.end(imageData);
-		}
-
-		throw new NotFoundException('Avatar not found');
 	}
 
 	async getFriends(userId: string) {
@@ -106,20 +84,11 @@ export class UsersService {
 		await this.userDao.updateFriendship(userId, id, status);
 	}
 
-	async updateAvatar(userId: string, avatar: Express.Multer.File) {
-		const avatarData = avatar.buffer;
-		return await this.userDao.updateAvatar(userId, avatarData);
-	}
-
 	async updateUser(userId: string, attrs: Partial<CreateUserDto>) {
 		return await this.userDao.updateUser(userId, attrs);
 	}
 
 	async deleteUser(userId: string) {
 		return await this.userDao.deleteUser(userId);
-	}
-
-	async deleteUserAvatar(userId: string) {
-		return await this.userDao.deleteUserAvatar(userId);
 	}
 }

--- a/web/src/components/UserProfile/UploadAvatarImage.tsx
+++ b/web/src/components/UserProfile/UploadAvatarImage.tsx
@@ -37,8 +37,8 @@ const UploadAvatarImage = () => {
 
 		try {
 			await fetch(
-				`${process.env.NEXT_PUBLIC_URL}/auth/upload` ||
-					'http://localhost:3000/auth/upload',
+				`${process.env.NEXT_PUBLIC_URL}/auth/avatar/upload` ||
+					'http://localhost:3000/auth/avatar/upload',
 				{
 					method: 'POST',
 					headers: { ...headers },

--- a/web/src/context/user.context.tsx
+++ b/web/src/context/user.context.tsx
@@ -41,8 +41,8 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
 		const headers = { Authorization: `${token}` };
 		try {
 			const response = await fetch(
-				`${process.env.NEXT_PUBLIC_URL}/auth/download` ||
-					'http://localhost:3000/auth/download',
+				`${process.env.NEXT_PUBLIC_URL}/auth/avatar/download` ||
+					'http://localhost:3000/auth/avatar/download',
 				{
 					method: 'GET',
 					headers: { ...headers },

--- a/web/src/utils/cinesync-api/fetch-user.ts
+++ b/web/src/utils/cinesync-api/fetch-user.ts
@@ -50,7 +50,7 @@ export const getUserAvatar = async ({
 	return await cinesyncFetch({
 		token,
 		method: 'GET',
-		endpoint: '/auth/download',
+		endpoint: '/auth/avatar/download',
 	});
 };
 
@@ -101,7 +101,7 @@ export const uploadUserAvatar = async ({
 	return await cinesyncFetch({
 		token,
 		method: 'POST',
-		endpoint: '/auth/upload',
+		endpoint: '/auth/avatar/upload',
 		body: body,
 	});
 };
@@ -141,6 +141,6 @@ export const deleteUserAvatar = async ({
 	return await cinesyncFetch({
 		token,
 		method: 'DELETE',
-		endpoint: '/auth/deleteAvatar',
+		endpoint: '/auth/avatar/delete',
 	});
 };


### PR DESCRIPTION
## Issue
Closes #110

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Refactor**: Refactors code
- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR refactors the avatar code into its own module and service inside the user folder, and creates a new Avatar table to store users avatars (_instead of storing them in the User table_.)

Originally I had set out to create some sort of system that would return an avatar url which can be called by our frontend. Half way through doing that I realized that we can instead simply add a new route which gets returns a user's avatar via their username (_which the `friends` and `sharees` routes both return_)

The new route takes the following shape : `GET {{BASE_URL}}/auth/avatar?username={username}`. As usual I'll provide the postman file.

![04 - 17h37m00s - get_current_user_avatar_-_Funnls_Workspace](https://github.com/chrispinkney/cinesync/assets/7242003/9b290fda-6da1-47cb-8da2-ad6ee1ae76bb)
![04 - 17h36m53s - get_specific_user_avatar_-_Funnls_Workspace](https://github.com/chrispinkney/cinesync/assets/7242003/c8243590-260e-4296-a9ae-a7fd70214ed4)

## Testing the PR
switch, pull, run backend + db, `npm run db:migrate`, `npm run db:generate`, hit route specified above

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
