### PR TITLE
Issue-75: Auto-Close Share Menu after Sharing

### DIFF
--- a/web/src/components/List/ListActions.tsx
+++ b/web/src/components/List/ListActions.tsx
@@ -56,6 +56,7 @@ const ListActions = ({
 			</Tooltip>
 			<ListShareModal
 				open={shareModalOpen}
+				setShareModalOpen={setShareModalOpen}
 				handleClose={handleShareModalClose}
 				listId={listId}
 				name={name}

--- a/web/src/components/List/ListShareModal.tsx
+++ b/web/src/components/List/ListShareModal.tsx
@@ -8,17 +8,19 @@ import Modal from '@mui/material/Modal';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { useGlobalContext } from '@/context/store';
 import { toggleListSharee } from '@/utils/cinesync-api/fetch-list';
 
 const ListShareModal = ({
 	open,
+	setShareModalOpen,
 	handleClose,
 	listId,
 	name,
 }: {
 	open: boolean;
+	setShareModalOpen: Dispatch<SetStateAction<boolean>>;
 	handleClose: () => void;
 	listId: string;
 	name: string;
@@ -53,6 +55,7 @@ const ListShareModal = ({
 			} else {
 				setRecipientEmail('');
 				setErrorText('');
+				setShareModalOpen(false);
 			}
 		}
 	};


### PR DESCRIPTION
## Issue
<!--
Automatically close the issue when this PR is merged
    USAGE: Fixes/Closes #<issue number>
-->
Fixes #75 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR implements an auto-close function to the move list share dialog.

Previously the modal would remain open upon share success, but it will now automatically close after the backend returns that the sharing has completed successfully.

## Testing the PR
<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->
Using Vercel preview, share a list with a user and verify the dialog closes automatically.

## Checklist
<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
