### PR TITLE
Issue-57: Implement public list route, add api wide auth

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_PIPE } from '@nestjs/core';
+import { APP_GUARD, APP_PIPE } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaService } from './prisma/prisma.service';
+import { JwtAuthGuard } from './users/guards/jwt-auth.guard';
 import { UsersModule } from './users/users.module';
 import { ListsModule } from './lists/lists.module';
 import { EmailModule } from './email/email.module';
@@ -14,6 +15,10 @@ import { AvatarModule } from './users/avatar/avatar.module';
 	imports: [ConfigModule, UsersModule, ListsModule, EmailModule, AvatarModule],
 	controllers: [AppController],
 	providers: [
+		{
+			provide: APP_GUARD,
+			useClass: JwtAuthGuard,
+		},
 		AppService,
 		{
 			provide: APP_PIPE,

--- a/api/src/lists/daos/list.dao.ts
+++ b/api/src/lists/daos/list.dao.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { UpdateListDto } from '../dtos/update-list.dto';
 import { CreateListDto } from '../dtos/create-list.dto';
@@ -6,6 +6,16 @@ import { CreateListDto } from '../dtos/create-list.dto';
 @Injectable()
 export class ListDao {
 	constructor(private readonly prisma: PrismaService) {}
+
+	async getPublicList(listId: string) {
+		const list = await this.getList(listId);
+
+		if (!list.isPrivate) {
+			return list;
+		}
+
+		throw new BadRequestException('List is private');
+	}
 
 	async getList(listId: string) {
 		const list = await this.prisma.list.findUniqueOrThrow({

--- a/api/src/lists/guards/list.guard.ts
+++ b/api/src/lists/guards/list.guard.ts
@@ -18,11 +18,6 @@ export class ListAuthorizationGuard implements CanActivate {
 			},
 		});
 
-		// allow access if list is public and user is logged in
-		if (!list.isPrivate && user) {
-			return true;
-		}
-
 		// restrict access if no user is logged in
 		if (!user) {
 			return false;

--- a/api/src/lists/lists.controller.ts
+++ b/api/src/lists/lists.controller.ts
@@ -22,14 +22,20 @@ import { CreateListDto } from './dtos/create-list.dto';
 import { UpdateListDto } from './dtos/update-list.dto';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { UpdateCommentDto } from './dtos/update-comment.dto';
-import { JwtAuthGuard } from '../users/guards/jwt-auth.guard';
 import { CommentAuthorizationGuard } from '../users/guards/comment-auth.guard';
 import { CloneListDto } from './dtos/clone-list.dto';
+import { Public } from '../users/decorators/public.decorator';
 
-@UseGuards(JwtAuthGuard)
 @Controller('lists')
 export class ListsController {
 	constructor(private listsService: ListsService) {}
+
+	@UseInterceptors(RemoveListCreateFieldsInterceptor)
+	@Public()
+	@Get('/public/list')
+	getPublicList(@Query('listId') listId: string) {
+		return this.listsService.getPublicList(listId);
+	}
 
 	@UseInterceptors(RemoveListCreateFieldsInterceptor)
 	@UseGuards(ListAuthorizationGuard)
@@ -45,7 +51,6 @@ export class ListsController {
 		return this.listsService.getLists(req.user.id);
 	}
 
-	@UseGuards(JwtAuthGuard)
 	@Get('/watched')
 	getWatchedMovies(@Req() req: Request) {
 		if (!req.user) throw new BadRequestException('req contains no user');
@@ -134,7 +139,6 @@ export class ListsController {
 	}
 
 	@UseInterceptors(RemoveListFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Patch('/updateWatchedStatus')
 	@HttpCode(HttpStatus.NO_CONTENT)
 	updateWatchedStatus(

--- a/api/src/lists/lists.service.ts
+++ b/api/src/lists/lists.service.ts
@@ -29,6 +29,10 @@ export class ListsService {
 		private emailService: EmailService,
 	) {}
 
+	async getPublicList(listId: string) {
+		return await this.listDao.getPublicList(listId);
+	}
+
 	async getList(listId: string) {
 		const list = await this.listDao.getList(listId);
 

--- a/api/src/users/decorators/public.decorator.ts
+++ b/api/src/users/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/api/src/users/guards/jwt-auth.guard.ts
+++ b/api/src/users/guards/jwt-auth.guard.ts
@@ -1,5 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+	constructor(private reflector: Reflector) {
+		super();
+	}
+
+	canActivate(context: ExecutionContext) {
+		const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+			context.getHandler(),
+			context.getClass(),
+		]);
+
+		if (isPublic) {
+			return true;
+		}
+
+		return super.canActivate(context);
+	}
+}

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -29,11 +29,11 @@ import { UpdateUserDto } from './dtos/update-user.dto';
 import { ListsService } from '../lists/lists.service';
 import { Response, Request } from 'express';
 import { LocalAuthGuard } from './guards/local-auth.guard';
-import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RemoveFieldsInterceptor } from './interceptors/remove-fields.interceptor';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { FriendStatus } from './users.service';
 import { AvatarService } from './avatar/avatar.service';
+import { Public } from './decorators/public.decorator';
 
 declare global {
 	// eslint-disable-next-line @typescript-eslint/no-namespace
@@ -58,42 +58,31 @@ export class UsersController {
 	) {}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Get('/whoami')
 	whoAmI(@Req() req: Request) {
 		return req.user;
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Get('/')
 	fetchUserById(@Query('userId') userId: string) {
 		return this.usersService.getUser(userId);
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Get('/username')
 	fetchUserByUsername(@Query('username') username: string) {
 		return this.usersService.getUserByUsername(username);
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Get('/email')
 	fetchUserByEmail(@Query('email') email: string) {
 		return this.usersService.getUserByEmail(email);
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
-	@Post('/signout')
-	@HttpCode(HttpStatus.NO_CONTENT)
-	signout(@Res({ passthrough: true }) response: Response) {
-		response.setHeader('Authorization', '');
-	}
-
-	@UseInterceptors(RemoveFieldsInterceptor)
+	@Public()
 	@Post('/signup')
 	async signup(@Body() body: CreateUserDto) {
 		const user = await this.authService.signup(body);
@@ -105,6 +94,7 @@ export class UsersController {
 
 	@UseInterceptors(RemoveFieldsInterceptor)
 	@UseGuards(LocalAuthGuard)
+	@Public()
 	@Post('/signin')
 	@HttpCode(HttpStatus.OK)
 	async signin(@Req() req: Request) {
@@ -114,7 +104,6 @@ export class UsersController {
 		return user;
 	}
 
-	@UseGuards(JwtAuthGuard)
 	@Get('/friends')
 	async getFriends(@Req() req: Request) {
 		if (!req.user) throw new BadRequestException('req contains no user');
@@ -122,7 +111,6 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Post('/friends/send')
 	@HttpCode(HttpStatus.NO_CONTENT)
 	async sendFriendRequest(
@@ -134,7 +122,6 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Post('/friends/update')
 	@HttpCode(HttpStatus.NO_CONTENT)
 	async updateFriendRequest(
@@ -150,7 +137,6 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Patch('/update')
 	async updateUser(@Req() req: Request, @Body() body: UpdateUserDto) {
 		if (!req.user) throw new BadRequestException('req contains no user');
@@ -164,7 +150,7 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard, AdminGuard)
+	@UseGuards(AdminGuard)
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@Delete('/delete')
 	async deleteUser(@Req() req: Request) {
@@ -185,7 +171,6 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Get('/avatar')
 	async downloadUsersAvatar(
 		@Query('username') username: string,
@@ -198,7 +183,6 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@Get('/avatar/download')
 	async downloadAvatar(@Req() req: Request, @Res() res: Response) {
 		if (!req.user) throw new BadRequestException('req contains no user');
@@ -207,7 +191,6 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard)
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@Post('/avatar/upload')
 	@UseInterceptors(FileInterceptor('image'))
@@ -228,7 +211,7 @@ export class UsersController {
 	}
 
 	@UseInterceptors(RemoveFieldsInterceptor)
-	@UseGuards(JwtAuthGuard, AdminGuard)
+	@UseGuards(AdminGuard)
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@Delete('/avatar/delete')
 	async deleteUserAvatar(@Req() req: Request) {


### PR DESCRIPTION
## Issue
Closes #57

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds a new public list route: `GET {{BASE_URL}}/lists/public/list?listId={{listId}}` which will allow any user (authenticated or non-authenticated- i.e., no Bearer token) to access a given list if (and only if) its `isPrivate` flag is set to false.

I'm also applying the JWTAuthGuard app wide now instead of just on all routes but one or two.

I'm having some difficulties that I can't seem to solve when applying the new `@Public()` decorator to the already established `GET {{BASE_URL}}/lists/list?listId={{listId}}` route. It doesn't want to play well with both public and authenticated users so I had to establish a new route. This is obviously less than ideal but I think on the frontend we can just see if `isPrivate` is set to false and if so change the url for the page to allow users to easily share that specific list's url. Non-authenticated users should not have access to app features (toggle privacy, share list, etc.) on the frontend but even if they do the backend won't allow them to be executed anyway.

## Testing the PR
Run through the app e2e as normal. Mark a list as public (via `PATCH {{BASE_URL}}/lists/updatePrivacy` in postman) and attempt to access the list with the new route with no auth token.

## Checklist
<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
