### PR TITLE
Issue-137: add back button to list page

### DIFF
--- a/web/src/components/List/MovieListGrid/MovieListTitle.tsx
+++ b/web/src/components/List/MovieListGrid/MovieListTitle.tsx
@@ -5,11 +5,15 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
+import UndoIcon from '@mui/icons-material/Undo';
 import { useMovieList } from '@/context/movielist.context';
 import { useState } from 'react';
 import TextField from '@mui/material/TextField';
+import Fab from '@mui/material/Fab';
+import { useRouter } from 'next/navigation';
 
 const MovieListTitle = ({ name }: { name: string }) => {
+	const { replace } = useRouter();
 	const { setMovieList, setListEdited } = useMovieList();
 	const [title, setTitle] = useState<string>(name);
 	const [editing, setEditing] = useState<boolean>(false);
@@ -43,6 +47,19 @@ const MovieListTitle = ({ name }: { name: string }) => {
 
 	return (
 		<Box display="flex" flexDirection="row" alignItems="center">
+			<Tooltip title="Back to lists">
+				<Fab
+					size="small"
+					color="primary"
+					aria-label="listsPage"
+					onClick={() => {
+						replace('/dashboard');
+					}}
+					sx={{ marginRight: 2 }}
+				>
+					<UndoIcon />
+				</Fab>
+			</Tooltip>
 			{!editing ? (
 				<>
 					<Typography


### PR DESCRIPTION
## Issue
<!--
Automatically close the issue when this PR is merged
    USAGE: Fixes/Closes #<issue number>
-->
closes #137 

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
<!-- Please add a detailed description of what this PR does and why it is needed -->
small PR that adds a back button to a list page so that the user does not have to click on cinesync logo

## Testing the PR
<!-- Please add steps to build the changes in your PR locally so that your PR can be tested
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error
 -->
run as normal and click on a list then click on back button.

## Checklist
<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes the respective npm run test and works locally
- [ ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
